### PR TITLE
fix(spegel): drop image digest override

### DIFF
--- a/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
@@ -23,9 +23,6 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    image:
-      repository: ghcr.io/spegel-org/spegel
-      digest: sha256:aee8841c5039df075bc8fdaf1e0f9d9d0943294c3a6fd7df5392ea037de36048
     spegel:
       containerdSock: /run/containerd/containerd.sock
       containerdRegistryConfigPath: /etc/cri/conf.d/hosts


### PR DESCRIPTION
## Summary
- Removes the pinned `image.digest` (sha256:aee8841c...) from the spegel HelmRelease
- Chart 0.7.1's default image (matching appVersion v0.7.1) wins, which is what we want

## Why
The pinned digest was a leftover from when this repo briefly used a `deedee-ops/spegel` fork. After switching back to upstream `ghcr.io/spegel-org/spegel`, the digest stayed frozen at the v0.0.30 image. Renovate has been bumping the chart but not the digest, so they drifted: chart 0.7.1's DaemonSet template now passes `--mirror-targets` to the binary, but the pinned v0.0.30 binary only understands `--mirror-registries` → init container crashloop after the spegel HR was unstuck via DaemonSet recreate.

Letting the chart pick its own image keeps them in sync going forward.

## Test plan
- [x] `task k8s:kubeconform` — passes
- [ ] Flux reconciles after merge; spegel HR goes Ready
- [ ] `kubectl get ds -n kube-system spegel` shows 5/5 ready
- [ ] `kubectl logs -n kube-system -l app.kubernetes.io/name=spegel -c configuration` — no `--mirror-targets` errors