### PR TITLE
Upgrade vidifierbot image to 0.7.0

### DIFF
--- a/kubernetes/apps/downloads/vidifier/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/vidifier/app/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
           app: # this can now be any name you wish
             image:
               repository: ghcr.io/cschmittiey/vidifierbot
-              tag: 0.6.4
+              tag: 0.7.0
               pullPolicy: IfNotPresent
 
             resources:


### PR DESCRIPTION
## Summary
Updates the vidifierbot container image tag from 0.6.4 to 0.7.0 in the Helm release configuration.

## Changes
- Bumped vidifierbot image tag from `0.6.4` to `0.7.0` in the downloads/vidifier Helm release

## Notes
This is a minor version upgrade of the vidifierbot application. Users should review the upstream release notes for 0.7.0 to understand any new features or breaking changes.

https://claude.ai/code/session_01AuxmyWiCTAgvSC2N1ipNqN